### PR TITLE
fix: construct dateLabelOptions as Object() by default

### DIFF
--- a/src/core/chart/BarChart.ts
+++ b/src/core/chart/BarChart.ts
@@ -68,7 +68,7 @@ export class BarChart extends BaseChart {
       this.barInfoFormat = options.barInfoFormat;
     if (options.showDateLabel !== undefined)
       this.showDateLabel = options.showDateLabel;
-    this.dateLabelOptions = options.dateLabelOptions;
+    this.dateLabelOptions = options.dateLabelOptions ?? Object();
     this.showRankLabel = options.showRankLabel ?? false;
     this.dy = options.dy ?? 0;
   }


### PR DESCRIPTION
In bar chart options, `dateLabelOptions` assigned by using `Object.assign` may cause type error when `dateLabelOptions` not initialized:
```
TypeError: Cannot convert undefined or null to object
    at Function.assign (<anonymous>)
    at BarChart.getComponent (/Users/robinlu/anichart.js/src/core/chart/BarChart.ts:253:37)
    at CanvasRenderer.render (/Users/robinlu/anichart.js/src/core/CanvasRenderer.ts:43:21)
    at /Users/robinlu/anichart.js/src/core/CanvasRenderer.ts:73:21
    at Array.forEach (<anonymous>)
    at CanvasRenderer.render (/Users/robinlu/anichart.js/src/core/CanvasRenderer.ts:72:21)
    at Stage.render (/Users/robinlu/anichart.js/src/core/Stage.ts:76:19)
    at Stage.doPlay (/Users/robinlu/anichart.js/src/core/Stage.ts:98:14)
    at /Users/robinlu/anichart.js/src/core/Stage.ts:85:12
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```